### PR TITLE
Add BigQuery integration to ETL pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ __pycache__/
 *.pyo
 *.pyd
 cleaned_data/
+gcp-key.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+gcp-key.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ COPY . .
 
 # Install pandas
 RUN pip install pandas
+RUN pip install google-cloud-bigquery pandas-gbq
 
 # Create cleaned_data folder in container
 RUN mkdir -p cleaned_data

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # AQ_Europe_ETL
-End to end ETL pipeline for processing European(EEA) air quality data
+End to end ETL pipeline for processing European(EEA) air quality data that processes European air quality data and uploads the cleaned dataset to Google BigQuery for analysis and visualization.
+
+## Features
+-  Extracts raw air quality data from CSV
+-  Cleans, filters, and deduplicates relevant fields
+-  Saves cleaned data locally and uploads to BigQuery
+
+## Tech Stack
+- **Python 3.10**
+- **Pandas**
+- **Google Cloud BigQuery**
+- **Docker**
+
+

--- a/etl.py
+++ b/etl.py
@@ -1,22 +1,31 @@
 import pandas as pd
 from rules.columns import extract_columns
+from loaders.upload import upload_to_bigquery
 
+# Upload raw data
 aq_annual_raw = pd.read_csv("raw_data/aq_annual_raw.csv")
 
 
 # List of preferred columns to extract
 columns_to_extract = ['Sampling Point Id', 'Air Pollutant', 'Air Pollution Level', 'Year', 'Air Quality Station Type', 'Air Quality Station Area', 'Longitude', 'Latitude']
-aq_annual_clean = extract_columns(aq_annual_raw, columns_to_extract)
 
-# Drop NANs and duplicates
+# Extract data and drop NANs/duplicates
+aq_annual_clean = extract_columns(aq_annual_raw, columns_to_extract)
 aq_annual_clean = aq_annual_clean.dropna().drop_duplicates()
 
 # Load clean data
 aq_annual_clean.to_csv("cleaned_data/aq_annual_clean.csv", index=False)
 
+upload_to_bigquery(
+    csv_path = "cleaned_data/aq_annual_clean.csv",
+    table_id = "aq-europe-etl.air_quality.aq_clean"
+)
+
+# logs
+print("Data extracted")
+print(f"Original dataset reduced from {len(aq_annual_raw)} rows to {len(aq_annual_clean)}")
+
 
 # For debugging
 print(aq_annual_clean.isnull().sum())
 print(aq_annual_clean.head(5))
-print("Original dataset reduced from " + str(len(aq_annual_raw)) + " rows to " + str(len(aq_annual_clean)) )
-print("data extracted")

--- a/loaders/upload.py
+++ b/loaders/upload.py
@@ -1,0 +1,18 @@
+from google.cloud import bigquery
+
+def upload_to_bigquery(csv_path, table_id):
+    client = bigquery.Client()
+    print(f"Authenticated project: {client.project}")
+    print(f"Uploading file: {csv_path} to table: {table_id}")
+
+    job_config = bigquery.LoadJobConfig(
+        source_format=bigquery.SourceFormat.CSV,
+        skip_leading_rows=1, # skip header
+        autodetect=True,
+    )
+
+    with open(csv_path, "rb") as source_file:
+        job = client.load_table_from_file(source_file, table_id, job_config=job_config)
+
+    job.result()
+    print(f"Uploaded to BigQuery table {table_id}")


### PR DESCRIPTION
This adds Google BigQuery integration to the ETL pipeline.

- Uploads cleaned CSV to BigQuery table (`aq_clean`)
- Adds `upload_to_bigquery()` function in `loaders/upload.py`
- Updates `etl.py` to include cloud upload
- Improves `.gitignore` and README 